### PR TITLE
Unified logSum and logDiff behavior, load and store facilities for matrices.

### DIFF
--- a/src/main/scala/scalala/library/Library.scala
+++ b/src/main/scala/scalala/library/Library.scala
@@ -40,6 +40,9 @@ trait Library {
   /** Alias for math.log. */
   final def log(v : Double) : Double = scala.math.log(v);
 
+  /** Alias for math.log1p. */
+  final def log1p(v : Double) : Double = scala.math.log1p(v);
+
   /** Alias for math.exp. */
   final def exp(v : Double) : Double = scala.math.exp(v);
 

--- a/src/main/scala/scalala/library/Numerics.scala
+++ b/src/main/scala/scalala/library/Numerics.scala
@@ -14,18 +14,19 @@
  limitations under the License.
 */
 
-package scalala.library;
+package scalala.library
 
-import math._;
+import math._
 
 /**
  * Provides some functions left out of java.lang.math.
  *
  * Borrowed from scalanlp.
  *
- * @author dlwh
+ * @author dlwh, afwlehmann
  */
 trait Numerics {
+
   /**
    * The standard digamma function. Cribbed from Radford Neal
    *
@@ -154,7 +155,10 @@ trait Numerics {
   * @return log(\sum exp(a_i))
   */
   def logSum(a: Double, b: Double, c: Double*): Double = {
-    logSum(Array(a, b) ++ c);
+    if (c.length == 0)
+      logSum(a, b)
+    else
+      logSum(logSum(a, b) +: c)
   }
 
   /**
@@ -162,16 +166,17 @@ trait Numerics {
   * @return log(\sum exp(a_i))
   */
   def logSum(iter: Iterator[Double], max: Double): Double = {
+    require(iter.hasNext)
     if (max.isInfinite) {
       max
     } else {
-      var accum = 0.0;
-      while (iter.hasNext) {
-        val b = iter.next
-        if (!b.isNegInfinity)
-          accum += exp(b - max)
+      val aux = (0.0 /: iter) {
+        (acc, x) => if (x.isNegInfinity) acc else acc + math.exp(x-max)
       }
-      max + log(accum)
+      if (aux != 0)
+        max + log(aux)
+      else
+        max
     }
   }
 
@@ -198,28 +203,6 @@ trait Numerics {
     else Double.NegativeInfinity
   }
 
-  //  import scalala.tensor.Vector;
-  //  /**
-  //  * Sums together things in log space.
-  //  * @return log(\sum exp(a_i))
-  //  */
-  //  def logSum(a:Vector):Double = a match {
-  //    case a: AdaptiveVector => logSum(a.innerVector);
-  //    case a: DenseVector => logSum(a.data);
-  //    case a: SparseVector => logSum(a.data.take(a.used));
-  //    case _ => logSum(a.activeValues,a.activeValues.reduceLeft(_ max _));
-  //  }
-
-  //  /**
-  //  * Sums together things in log space.
-  //  * @return log(\sum exp(a_i))
-  //  */
-  //  def logNormalize(a:Vector):Vector = {
-  //    val sum = logSum(a);
-  //    import scalala.Scalala.{logSum => _, _};
-  //    a - sum value;
-  //  }
-
   /**
    * Computes the polynomial P(x) with coefficients given in the passed in array.
    * coefs(i) is the coef for the x^i term.
@@ -233,7 +216,7 @@ trait Numerics {
     }
     p
   }
+
 }
 
-object Numerics extends Numerics;
-
+object Numerics extends Numerics

--- a/src/main/scala/scalala/library/Storage.scala
+++ b/src/main/scala/scalala/library/Storage.scala
@@ -1,0 +1,116 @@
+/*
+ * Distributed as part of Scalala, a linear algebra library.
+ *
+ * Copyright (C) 2008- Daniel Ramage
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110 USA
+ */
+
+package scalala.library
+
+
+import scalala.tensor.{::, Matrix}
+import scalala.tensor.dense.DenseMatrix
+import java.io._
+import util.matching.Regex
+
+trait Storage {
+
+  /**
+   * Deserializes a DenseMatrix from the given input stream.
+   *
+   * @param is
+   *  the input stream
+   * @param skipRows
+   *  number of lines to skip at the beginning
+   * @param columns
+   *  indices of the columns to be used, or null for all columns (default), e.g.
+   *  List(1,3) for columns 2 and 4, respectively
+   * @param delimiter
+   *  a regular expression defining the delimiter that is used to separate the
+   *  values
+   * @param comments
+   *  a regular expression defining the start of comments which will be removed
+   *  throughout the process
+   */
+  def loadtxt(is: InputStream,
+              skipRows: Int = 0,
+              columns: Seq[Int] = null,
+              delimiter: Regex = Storage.defaultDelimiter,
+              comments: Regex = Storage.defaultComments):
+    DenseMatrix[Double] =
+  {
+    require(skipRows >= 0)
+    require(columns == null || columns.size > 0)
+
+    val it = new Iterator[Array[String]] {
+      val br = new BufferedReader(new InputStreamReader(is))
+      def hasNext = br.ready
+      def next =
+        // Regex.split actually returns an Array("") in case of an empty
+        // input string yet we want Array.empty instead, thus:
+        delimiter split (comments replaceFirstIn (br.readLine, "") trim) match {
+          case Array("") => Array.empty[String]
+          case r => r
+        }
+    }
+
+    for (i <- 0 until skipRows if it.hasNext) { it.next() }
+
+    var numCols = -1
+    val rows: Array[Array[Double]] =
+      (for (tokens <- it if !tokens.isEmpty) yield {
+        if (tokens.size != numCols) {
+          if (numCols == -1)
+            numCols = tokens.size
+          else
+            throw new RuntimeException("All lines must have the same number of columns!")
+        }
+        if (columns == null)
+          tokens.map(_.toDouble).toArray[Double]
+        else
+          ((for (colIdx <- columns) yield
+            tokens(colIdx).toDouble)).toArray[Double]
+      }).toArray
+
+    if (rows.size > 0)
+      DenseMatrix(rows:_*)
+    else
+      null
+  }
+
+
+  /**
+   * Serializes the given matrix to the given output stream. The given delimiter
+   * is used to separate the values of each row.
+   */
+  def storetxt(os: OutputStream, m: Matrix[Double], delimiter: String = "\t") {
+    val bw = new BufferedWriter(new OutputStreamWriter(os))
+    for (i <- 0 until m.numRows) {
+      bw.write(m(i,::).iterator map ("% 23.17g".format(_)) mkString delimiter)
+      bw.newLine()
+    }
+    bw.flush()
+  }
+
+
+}
+
+object Storage extends Storage {
+
+  val defaultDelimiter: Regex = """\s+""".r
+  val defaultComments: Regex = """#.*$""".r
+
+}

--- a/src/main/scala/scalala/tensor/generic/TensorValuesMonadic.scala
+++ b/src/main/scala/scalala/tensor/generic/TensorValuesMonadic.scala
@@ -33,14 +33,14 @@ import scalala.generic.collection._;
 trait TensorValuesMonadic
 [@specialized(Int,Long) K, @specialized(Int,Long,Float,Double) V,
  +This<:Tensor[K,V]] {
-  
+
   /** Underlying tensor. */
   def repr : This;
-  
+
   /** Calls repr.foreachValue. */
   def foreach[U](fn : V => U) =
     repr.foreachValue(fn);
-  
+
   /** Calls repr.mapValues. */
   def map[TT>:This,O,That](fn : V => O)
   (implicit bf : CanMapValues[TT, V, O, That]) : That =
@@ -49,27 +49,31 @@ trait TensorValuesMonadic
   /** Calls repr.valuesIterator. */
   def iterator =
     repr.valuesIterator;
-  
+
   /** Constructs a filtered view of this tensor. */
   def filter[D,That](p : V => Boolean) =
     withFilter(p);
-  
+
   /** Constructs a filtered view of this tensor. */
   def withFilter(p : V => Boolean) =
     new TensorValuesMonadic.Filtered[K,V,This](repr, p);
 
-  def reduceLeft[B >: V](op: (B, V) => B): B = {
-    var first = true
-    var acc: B = repr.scalar.zero
-    for (x <- this) {
-      if (first) {
-        acc = x
-        first = false
-      }
-      else acc = op(acc, x)
-    }
-    acc
-  }
+  /** Proxy for iterator.reduceLeft */
+  def reduceLeft[B >: V](op: (B, V) => B): B =
+    iterator.reduceLeft(op)
+
+  /** Proxy for iterator.reduceRight */
+  def reduceRight[B >: V](op: (V, B) => B): B =
+    iterator.reduceRight(op)
+
+  /** Proxy for iterator.foldLeft */
+  def foldLeft[B](initialValue: B)(op: (B, V) => B): B =
+    iterator.foldLeft(initialValue)(op)
+
+  /** Proxy for iterator.foldRight */
+  def foldRight[B](initialValue: B)(op: (V, B) => B): B =
+    iterator.foldRight(initialValue)(op)
+
 }
 
 object TensorValuesMonadic {
@@ -82,14 +86,14 @@ object TensorValuesMonadic {
 
     def withFilter(q : V => Boolean) =
       new Filtered[K,V,This](repr, v => p(v) && q(v));
-    
+
 //    def map[U,D,That](fn : V => U)
 //    (implicit df : CanGetDomain[This,D], bf : CanBuildTensorFrom[This,D,K,U,That]) = {
 //      val builder = bf(repr, repr.domain.asInstanceOf[D]);
 //      repr.foreachPair((k,v) => if (p(v)) builder(k) = fn(v));
 //      builder.result;
 //    }
-//    
+//
 //    def strict[D,That]
 //    (implicit df : CanGetDomain[This,D], bf : CanBuildTensorFrom[This,D,K,V,That]) = {
 //      val builder = bf(repr, repr.domain.asInstanceOf[D]);
@@ -97,7 +101,7 @@ object TensorValuesMonadic {
 //      builder.result;
 //    }
   }
-  
+
   implicit def asIterable[K, @specialized(Int,Long,Float,Double) V, T<:Tensor[K,V]]
   (values : TensorValuesMonadic[K,V,T]) = {
     new Iterable[V] {

--- a/src/test/scala/scalala/library/NumericsTest.scala
+++ b/src/test/scala/scalala/library/NumericsTest.scala
@@ -17,14 +17,13 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110 USA
  */
-package scalala;
-package library;
+package scalala.library
 
-import org.scalatest._;
-import org.scalatest.junit._;
-import org.scalatest.prop._;
-import org.scalatest.matchers.ShouldMatchers;
-import org.junit.runner.RunWith;
+import org.scalatest._
+import org.scalatest.junit._
+import org.scalatest.prop._
+import org.scalatest.matchers.ShouldMatchers
+import org.junit.runner.RunWith
 import Library._
 import Numerics._
 
@@ -37,11 +36,16 @@ class NumericsTest extends FunSuite with Checkers with ShouldMatchers {
     logSum(log(2), log(5)) should be (log(7) plusOrMinus 1e-10)
     logSum(Double.NegativeInfinity, log(5)) should be (log(5) plusOrMinus 1e-10)
     logSum(log(5), Double.NegativeInfinity) should be (log(5) plusOrMinus 1e-10)
+    logSum(Double.NegativeInfinity, Double.NegativeInfinity) should be (Double.NegativeInfinity)
+
+    logSum(log(1), log(2), log(3)) should be (log(6) plusOrMinus 1e-10)
+    logSum(log(1), log(2), Double.NegativeInfinity) should be (log(3) plusOrMinus(1e-10))
 
     val s = Array.tabulate[Double](5)(i => log1p(i))
-    logSum(s.iterator, log(5)) should be (log(15) plusOrMinus 1e-10)
+    logSum(s.iterator, s.max) should be (log(15) plusOrMinus 1e-10)
     logSum(s) should be (log(15) plusOrMinus 1e-10)
     logSum(Double.NegativeInfinity +: s) should be (log(15) plusOrMinus 1e-10)
+    logSum(s :+ Double.NegativeInfinity) should be (log(15) plusOrMinus 1e-10)
   }
 
   test("logDiff") {

--- a/src/test/scala/scalala/library/NumericsTest.scala
+++ b/src/test/scala/scalala/library/NumericsTest.scala
@@ -1,0 +1,56 @@
+/*
+ * Distributed as part of Scalala, a linear algebra library.
+ *
+ * Copyright (C) 2008- Daniel Ramage
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110 USA
+ */
+package scalala;
+package library;
+
+import org.scalatest._;
+import org.scalatest.junit._;
+import org.scalatest.prop._;
+import org.scalatest.matchers.ShouldMatchers;
+import org.junit.runner.RunWith;
+import Library._
+import Numerics._
+
+
+@RunWith(classOf[JUnitRunner])
+class NumericsTest extends FunSuite with Checkers with ShouldMatchers {
+
+  test("logSum") {
+    logSum(log(5), log(2)) should be (log(7) plusOrMinus 1e-10)
+    logSum(log(2), log(5)) should be (log(7) plusOrMinus 1e-10)
+    logSum(Double.NegativeInfinity, log(5)) should be (log(5) plusOrMinus 1e-10)
+    logSum(log(5), Double.NegativeInfinity) should be (log(5) plusOrMinus 1e-10)
+
+    val s = Array.tabulate[Double](5)(i => log1p(i))
+    logSum(s.iterator, log(5)) should be (log(15) plusOrMinus 1e-10)
+    logSum(s) should be (log(15) plusOrMinus 1e-10)
+    logSum(Double.NegativeInfinity +: s) should be (log(15) plusOrMinus 1e-10)
+  }
+
+  test("logDiff") {
+    logDiff(log(5), log(2)) should be (log(3) plusOrMinus 1e-10)
+    logDiff(log(5), log(5)) should be (Double.NegativeInfinity)
+
+    evaluating {
+      logDiff(log(5), log(6))
+    } should produce [IllegalArgumentException]
+  }
+
+}

--- a/src/test/scala/scalala/library/StorageTest.scala
+++ b/src/test/scala/scalala/library/StorageTest.scala
@@ -1,0 +1,69 @@
+/*
+ * Distributed as part of Scalala, a linear algebra library.
+ *
+ * Copyright (C) 2008- Daniel Ramage
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110 USA
+ */
+package scalala.library
+
+
+import org.scalatest._
+import org.scalatest.junit._
+import org.scalatest.prop._
+import org.scalatest.matchers.ShouldMatchers
+import org.junit.runner.RunWith
+import scalala.tensor.dense.DenseMatrix
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+
+
+@RunWith(classOf[JUnitRunner])
+class StorageTest extends FunSuite with Checkers with ShouldMatchers {
+
+  test("StoreTxtAndLoadTxt") {
+    val os = new ByteArrayOutputStream
+
+    val m = DenseMatrix.randn(5,5)
+    Storage.storetxt(os, m)
+    val n = Storage.loadtxt(new ByteArrayInputStream(os.toByteArray))
+    m foreachPair ((idx,v) => n(idx) should be (v plusOrMinus 1e-16))
+
+    os.reset()
+    Storage.storetxt(os, m)
+    val o = Storage.loadtxt(new ByteArrayInputStream(os.toByteArray), skipRows=2)
+    o.numRows should be (m.numRows-2)
+    o foreachPair ((idx,v) => m(idx._1+2,idx._2) should be (v plusOrMinus 1e-16))
+
+    os.reset()
+    Storage.storetxt(os, m)
+    val p = Storage.loadtxt(new ByteArrayInputStream(os.toByteArray), columns=Seq(1,3))
+    p.numCols should be (2)
+    p foreachPair {
+      case ((row,0), v) => m(row,1) should be (v plusOrMinus 1e-16)
+      case ((row,1), v) => m(row,3) should be (v plusOrMinus 1e-16)
+      case _ => true should be (false) // signal failure
+    }
+
+    val is = new ByteArrayInputStream("1.0 2.0 #test\n#foo\n3.0 4.0".getBytes)
+    val r = Storage.loadtxt(is)
+    r.numRows should be (2)
+    r.numCols should be (2)
+    r(0,0) should be (1.0)
+    r(0,1) should be (2.0)
+    r(1,0) should be (3.0)
+    r(1,1) should be (4.0)
+  }
+
+}


### PR DESCRIPTION
Adapted logSum and logDiff such that they have the same consistent behavior w.r.t. the (extended) logarithm of 0 represented (also before) by Double.NegativeInfinity.

Wrote unit tests to assure the correct behavior.

2nd commit fixes a bug that I accidentally introduced in the first commit.

Corresponding to the addition of reduceLeft by Daniel, I added reduceRight, foldLeft and foldRight. However, instead of using own implementations I think it might be advantageous to use the iterator's supplied methods and only provide appropriate proxies. If you feel this is not what you want please make sure that reduceLeft throws an UnsupportedOperationException in case of an empty dataset (so does Scala's stdlib, e.g. List.empty[Double] reduceLeft (_+_)).

Added load and store facilities for matrices.
