### PR TITLE
test showing how wrong operator is picked if DenseVector is up casted (jo

### DIFF
--- a/src/test/scala/scalala/tensor/dense/DenseVectorTest.scala
+++ b/src/test/scala/scalala/tensor/dense/DenseVectorTest.scala
@@ -26,16 +26,17 @@ import org.scalatest._;
 import org.scalatest.junit._;
 import org.scalatest.prop._;
 import org.junit.runner.RunWith
+import mutable.Tensor;
 
 @RunWith(classOf[JUnitRunner])
 class DenseVectorTest extends FunSuite with Checkers {
 
   val TOLERANCE = 1e-4;
-  def assertClose(a : Double, b : Double) =
+  def assertClose(a: Double, b: Double) =
     assert(math.abs(a - b) < TOLERANCE);
 
   test("Min/Max") {
-    val v = DenseVector(2,0,3,2,-1);
+    val v = DenseVector(2, 0, 3, 2, -1);
     assert(v.argmin === 4);
     assert(v.argmax === 2);
     assert(v.min === -1);
@@ -43,7 +44,7 @@ class DenseVectorTest extends FunSuite with Checkers {
   }
 
   test("Norm") {
-    val v = DenseVector(-0.4326,-1.6656,0.1253,0.2877,-1.1465);
+    val v = DenseVector(-0.4326, -1.6656, 0.1253, 0.2877, -1.1465);
     assertClose(v.norm(1), 3.6577);
     assertClose(v.norm(2), 2.0915);
     assertClose(v.norm(3), 1.8405);
@@ -54,8 +55,8 @@ class DenseVectorTest extends FunSuite with Checkers {
   }
 
   test("MulInner") {
-    val a = DenseVector(0.56390,0.36231,0.14601,0.60294,0.14535);
-    val b = DenseVector(0.15951,0.83671,0.56002,0.57797,0.54450);
+    val a = DenseVector(0.56390, 0.36231, 0.14601, 0.60294, 0.14535);
+    val b = DenseVector(0.15951, 0.83671, 0.56002, 0.57797, 0.54450);
     assertClose(a dot b, .90249);
     assertClose(a.t * b, .90249);
   }
@@ -65,16 +66,16 @@ class DenseVectorTest extends FunSuite with Checkers {
     val b = DenseVector(6, -4, 8);
 
     // assert result is a dense matrix
-    val m : DenseMatrix[Int] = a * b.t;
-    assert(m === DenseMatrix((6,-4,8),(12,-8,16),(18,-12,24)));
+    val m: DenseMatrix[Int] = a * b.t;
+    assert(m === DenseMatrix((6, -4, 8), (12, -8, 16), (18, -12, 24)));
   }
 
   test("MulMatrix") {
-    val x = DenseVector(1,2).t;
-    val m = DenseMatrix((1,2,1),(2,7,8));
+    val x = DenseVector(1, 2).t;
+    val m = DenseMatrix((1, 2, 1), (2, 7, 8));
 
     // assert return type is statically a dense row
-    val r : DenseVectorRow[Int] = x * m;
+    val r: DenseVectorRow[Int] = x * m;
     assert(r === DenseVector(5, 16, 17));
   }
 
@@ -82,16 +83,20 @@ class DenseVectorTest extends FunSuite with Checkers {
     val x = DenseVector.zeros[Int](5);
 
     // check that the slice is a vector and mutable
-    val y : mutable.Vector[Int] = x(0 to 2);
+    val y: mutable.Vector[Int] = x(0 to 2);
     y :+= 1;
 
-    val z : mutable.Vector[Int] = x(1 to 3);
+    val z: mutable.Vector[Int] = x(1 to 3);
     z :+= 1;
 
-    assert(x === DenseVector(1,2,2,1,0));
+    assert(x === DenseVector(1, 2, 2, 1, 0));
 
     assert(x(0 until 5) === x);
-    assert(try { x(0 to 5); false; } catch { case _ => true });
+    assert(try {
+      x(0 to 5); false;
+    } catch {
+      case _ => true
+    });
   }
 
   test("Slice and Transpose") {
@@ -106,23 +111,47 @@ class DenseVectorTest extends FunSuite with Checkers {
     assert(t === DenseVector(3, 4).t);
   }
 
+  test("Combined Assignment Bug: Picks wrong operator") {
+    val a = DenseVector(13, 42);
+    val b = DenseVector(7, 42);
+    val expected = DenseVector(6, 0);
+
+    val direct = a - b;
+    assert(direct === expected);
+
+    (a: Tensor[Int, Int]) :-= b;
+    assert(a === expected);
+  }
+
+  test("Combined Assignment Bug: Picks correct operator") {
+    val a = DenseVector(13, 42);
+    val b = DenseVector(7, 42);
+    val expected = DenseVector(6, 0);
+
+    val direct = a - b;
+    assert(direct === expected);
+
+    a :-= b;
+    assert(a === expected);
+  }
+
   test("Transpose") {
-    val x : DenseVectorCol[Int] = DenseVector(1,2,3);
+    val x: DenseVectorCol[Int] = DenseVector(1, 2, 3);
 
     // test static type and write-through of transpose
-    val y : DenseVectorRow[Int] = x.t;
+    val y: DenseVectorRow[Int] = x.t;
     y(0) = 0;
-    assert(x === DenseVector(0,2,3));
+    assert(x === DenseVector(0, 2, 3));
   }
 
   test("MapValues") {
-    val a : DenseVector[Int] = DenseVector(1,2,3,4,5);
-    val m : DenseVector[Int] = a.mapValues(_ + 1);
-    assert(m === DenseVector(2,3,4,5,6));
+    val a: DenseVector[Int] = DenseVector(1, 2, 3, 4, 5);
+    val m: DenseVector[Int] = a.mapValues(_ + 1);
+    assert(m === DenseVector(2, 3, 4, 5, 6));
   }
 
   test("ForComprehensions") {
-    val a : DenseVectorCol[Int] = DenseVector(1,2,3,4,5);
+    val a: DenseVectorCol[Int] = DenseVector(1, 2, 3, 4, 5);
 
     var s = 0;
 
@@ -134,30 +163,30 @@ class DenseVectorTest extends FunSuite with Checkers {
     // filter
     s = 0;
     for (v <- a; if v < 3) s += v;
-    assert(s === 1+2);
+    assert(s === 1 + 2);
 
     // map
-    val b1 : DenseVectorCol[Double] = for (v <- a) yield v * 2.0;
-    assert(b1 === DenseVector(2.0,4.0,6.0,8.0,10.0));
+    val b1: DenseVectorCol[Double] = for (v <- a) yield v * 2.0;
+    assert(b1 === DenseVector(2.0, 4.0, 6.0, 8.0, 10.0));
 
     // map with filter
-    val b2 : DenseVectorCol[Int] = for (v <- a; if v < 3) yield v * 2;
-    assert(b2 === DenseVector(2.0,4.0));
+    val b2: DenseVectorCol[Int] = for (v <- a; if v < 3) yield v * 2;
+    assert(b2 === DenseVector(2.0, 4.0));
 
     // transpose map with filter
-    val b3 : DenseVectorRow[Int] = for (v <- a.t; if v < 3) yield v * 3;
-    assert(b3 === DenseVector(3,6).t);
+    val b3: DenseVectorRow[Int] = for (v <- a.t; if v < 3) yield v * 3;
+    assert(b3 === DenseVector(3, 6).t);
   }
 
   test("Tabulate") {
     val m = DenseVector.tabulate(5)(i => i + 1);
-    assert(m === DenseVector(1,2,3,4,5));
+    assert(m === DenseVector(1, 2, 3, 4, 5));
   }
 
   test("VertCat") {
-    val a1 = DenseVector(1,2,3);
-    val a2 = DenseVector(2,3,4);
-    val res = DenseVector(1,2,3,2,3,4);
-    assert(DenseVector.vertcat(a1,a2) === res);
+    val a1 = DenseVector(1, 2, 3);
+    val a2 = DenseVector(2, 3, 4);
+    val res = DenseVector(1, 2, 3, 2, 3, 4);
+    assert(DenseVector.vertcat(a1, a2) === res);
   }
 }

--- a/src/test/scala/scalala/tensor/dense/DenseVectorTest.scala
+++ b/src/test/scala/scalala/tensor/dense/DenseVectorTest.scala
@@ -32,11 +32,11 @@ import mutable.Tensor;
 class DenseVectorTest extends FunSuite with Checkers {
 
   val TOLERANCE = 1e-4;
-  def assertClose(a: Double, b: Double) =
+  def assertClose(a : Double, b : Double) =
     assert(math.abs(a - b) < TOLERANCE);
 
   test("Min/Max") {
-    val v = DenseVector(2, 0, 3, 2, -1);
+    val v = DenseVector(2,0,3,2,-1);
     assert(v.argmin === 4);
     assert(v.argmax === 2);
     assert(v.min === -1);
@@ -44,7 +44,7 @@ class DenseVectorTest extends FunSuite with Checkers {
   }
 
   test("Norm") {
-    val v = DenseVector(-0.4326, -1.6656, 0.1253, 0.2877, -1.1465);
+    val v = DenseVector(-0.4326,-1.6656,0.1253,0.2877,-1.1465);
     assertClose(v.norm(1), 3.6577);
     assertClose(v.norm(2), 2.0915);
     assertClose(v.norm(3), 1.8405);
@@ -55,8 +55,8 @@ class DenseVectorTest extends FunSuite with Checkers {
   }
 
   test("MulInner") {
-    val a = DenseVector(0.56390, 0.36231, 0.14601, 0.60294, 0.14535);
-    val b = DenseVector(0.15951, 0.83671, 0.56002, 0.57797, 0.54450);
+    val a = DenseVector(0.56390,0.36231,0.14601,0.60294,0.14535);
+    val b = DenseVector(0.15951,0.83671,0.56002,0.57797,0.54450);
     assertClose(a dot b, .90249);
     assertClose(a.t * b, .90249);
   }
@@ -66,16 +66,16 @@ class DenseVectorTest extends FunSuite with Checkers {
     val b = DenseVector(6, -4, 8);
 
     // assert result is a dense matrix
-    val m: DenseMatrix[Int] = a * b.t;
-    assert(m === DenseMatrix((6, -4, 8), (12, -8, 16), (18, -12, 24)));
+    val m : DenseMatrix[Int] = a * b.t;
+    assert(m === DenseMatrix((6,-4,8),(12,-8,16),(18,-12,24)));
   }
 
   test("MulMatrix") {
-    val x = DenseVector(1, 2).t;
-    val m = DenseMatrix((1, 2, 1), (2, 7, 8));
+    val x = DenseVector(1,2).t;
+    val m = DenseMatrix((1,2,1),(2,7,8));
 
     // assert return type is statically a dense row
-    val r: DenseVectorRow[Int] = x * m;
+    val r : DenseVectorRow[Int] = x * m;
     assert(r === DenseVector(5, 16, 17));
   }
 
@@ -83,20 +83,16 @@ class DenseVectorTest extends FunSuite with Checkers {
     val x = DenseVector.zeros[Int](5);
 
     // check that the slice is a vector and mutable
-    val y: mutable.Vector[Int] = x(0 to 2);
+    val y : mutable.Vector[Int] = x(0 to 2);
     y :+= 1;
 
-    val z: mutable.Vector[Int] = x(1 to 3);
+    val z : mutable.Vector[Int] = x(1 to 3);
     z :+= 1;
 
-    assert(x === DenseVector(1, 2, 2, 1, 0));
+    assert(x === DenseVector(1,2,2,1,0));
 
     assert(x(0 until 5) === x);
-    assert(try {
-      x(0 to 5); false;
-    } catch {
-      case _ => true
-    });
+    assert(try { x(0 to 5); false; } catch { case _ => true });
   }
 
   test("Slice and Transpose") {
@@ -136,22 +132,22 @@ class DenseVectorTest extends FunSuite with Checkers {
   }
 
   test("Transpose") {
-    val x: DenseVectorCol[Int] = DenseVector(1, 2, 3);
+    val x : DenseVectorCol[Int] = DenseVector(1,2,3);
 
     // test static type and write-through of transpose
-    val y: DenseVectorRow[Int] = x.t;
+    val y : DenseVectorRow[Int] = x.t;
     y(0) = 0;
-    assert(x === DenseVector(0, 2, 3));
+    assert(x === DenseVector(0,2,3));
   }
 
   test("MapValues") {
-    val a: DenseVector[Int] = DenseVector(1, 2, 3, 4, 5);
-    val m: DenseVector[Int] = a.mapValues(_ + 1);
-    assert(m === DenseVector(2, 3, 4, 5, 6));
+    val a : DenseVector[Int] = DenseVector(1,2,3,4,5);
+    val m : DenseVector[Int] = a.mapValues(_ + 1);
+    assert(m === DenseVector(2,3,4,5,6));
   }
 
   test("ForComprehensions") {
-    val a: DenseVectorCol[Int] = DenseVector(1, 2, 3, 4, 5);
+    val a : DenseVectorCol[Int] = DenseVector(1,2,3,4,5);
 
     var s = 0;
 
@@ -163,30 +159,30 @@ class DenseVectorTest extends FunSuite with Checkers {
     // filter
     s = 0;
     for (v <- a; if v < 3) s += v;
-    assert(s === 1 + 2);
+    assert(s === 1+2);
 
     // map
-    val b1: DenseVectorCol[Double] = for (v <- a) yield v * 2.0;
-    assert(b1 === DenseVector(2.0, 4.0, 6.0, 8.0, 10.0));
+    val b1 : DenseVectorCol[Double] = for (v <- a) yield v * 2.0;
+    assert(b1 === DenseVector(2.0,4.0,6.0,8.0,10.0));
 
     // map with filter
-    val b2: DenseVectorCol[Int] = for (v <- a; if v < 3) yield v * 2;
-    assert(b2 === DenseVector(2.0, 4.0));
+    val b2 : DenseVectorCol[Int] = for (v <- a; if v < 3) yield v * 2;
+    assert(b2 === DenseVector(2.0,4.0));
 
     // transpose map with filter
-    val b3: DenseVectorRow[Int] = for (v <- a.t; if v < 3) yield v * 3;
-    assert(b3 === DenseVector(3, 6).t);
+    val b3 : DenseVectorRow[Int] = for (v <- a.t; if v < 3) yield v * 3;
+    assert(b3 === DenseVector(3,6).t);
   }
 
   test("Tabulate") {
     val m = DenseVector.tabulate(5)(i => i + 1);
-    assert(m === DenseVector(1, 2, 3, 4, 5));
+    assert(m === DenseVector(1,2,3,4,5));
   }
 
   test("VertCat") {
-    val a1 = DenseVector(1, 2, 3);
-    val a2 = DenseVector(2, 3, 4);
-    val res = DenseVector(1, 2, 3, 2, 3, 4);
-    assert(DenseVector.vertcat(a1, a2) === res);
+    val a1 = DenseVector(1,2,3);
+    val a2 = DenseVector(2,3,4);
+    val res = DenseVector(1,2,3,2,3,4);
+    assert(DenseVector.vertcat(a1,a2) === res);
   }
 }


### PR DESCRIPTION
Please have a look at this test case.

If I cast a DenseVector to a Tensor and do something like a :-= b then the wrong operator implementation and some optimization kicks. If an operation on an element results to zero then that operation is executed again... 
(Tensor.Scala: joinEitherNonZero)
