### PR TITLE
Add matrix rank() method.

### DIFF
--- a/src/main/scala/scalala/library/LinearAlgebra.scala
+++ b/src/main/scala/scalala/library/LinearAlgebra.scala
@@ -433,6 +433,28 @@ trait LinearAlgebra {
     )
   }
 
+  /**
+   * Computes the rank of a DenseMatrix[Double].
+   *
+   * The rank of the matrix is computed using the SVD method.  The singular values of the SVD
+   * which are greater than a specified tolerance are counted.
+   *
+   * @param m matrix for which to compute the rank
+   * @param tol optional tolerance for singular values.  If not supplied, the default
+   *   tolerance is: max(m.numCols, m.numRows) * eps * sigma_max, where
+   *   eps is the machine epsilon and sigma_max is the largest singular value of m.
+   * @return the rank of the matrix (number of singular values)
+   */
+  def rank(m: DenseMatrix[Double], tol: Option[Double] = None): Int = {    
+    val (u, s, vt) = svd(m)
+    val useTol = tol.getOrElse {
+      // we called LAPACK for the SVD method, so this is the LAPACK definition of eps.
+      val eps: Double = 2.0 * LAPACK.getInstance.dlamch("e")
+      math.max(m.numCols, m.numRows) * eps * s.max
+    }
+    s.data.count(_ > useTol)  // TODO: Use DenseVector[_].count() if/when that is implemented
+  }
+
 }
 
 object LinearAlgebra extends LinearAlgebra;

--- a/src/test/scala/scalala/library/LinearAlgebraTest.scala
+++ b/src/test/scala/scalala/library/LinearAlgebraTest.scala
@@ -125,4 +125,13 @@ class LinearAlgebraTest extends FunSuite with Checkers with ShouldMatchers {
     }
   }
 
+  test("rank") {
+    val r1 = Matrix((1.,2.,3.), (1.,2.,3.), (1.,2.,3.))  // rank 1 matrix
+    val r2 = Matrix((1.,2.,3.), (4.,5.,6.), (7.,8.,9.))  // rank 2 matrix
+    val r3 = Matrix((1.,2.,3.), (4.,5.,6.), (6.,8.,9.))  // rank 3 matrix
+    assert(rank(r1) === 1)
+    assert(rank(r2) === 2)
+    assert(rank(r3) === 3)
+  }
+
 }


### PR DESCRIPTION
This pull request adds a scalala.library.LinearAlgebra.rank() method, which estimates the rank of a matrix by counting the singular values of the SVD method.  Both Octave and Matlab also use SVD to compute rank.
