### PR TITLE
Fix for Issue #21: det() method is incorrect.

### DIFF
--- a/src/main/scala/scalala/library/LinearAlgebra.scala
+++ b/src/main/scala/scalala/library/LinearAlgebra.scala
@@ -345,8 +345,15 @@ trait LinearAlgebra {
     // Since det(AB) = det(A) * det(B), the LU factorization is well-suited for
     // the computation of the determinant of general N-by-N matrices.
     val (m, ipiv) = LU(X)
-    val numExchangedRows = (0 /: ipiv)(_ + math.min(1,_))
-    var acc = if (numExchangedRows % 2 == 1) 1.0 else -1.0
+
+    // Count the number of exchanged rows.  ipiv contains an array of swapped indices,
+    //  but it also contains indices that weren't swapped.  To count the swapped
+    //  indices, we have to compare them against their position within the array.  A
+    //  final complication is that the array indices are 1-based, due to the LU call
+    //  into LAPACK.
+    val numExchangedRows = ipiv.map(_ - 1).zipWithIndex.count { piv => piv._1 != piv._2 }
+
+    var acc = if (numExchangedRows % 2 == 1) -1.0 else 1.0
     for (i <- 0 until m.numRows)
       acc *= m(i,i)
 

--- a/src/test/scala/scalala/library/LinearAlgebraTest.scala
+++ b/src/test/scala/scalala/library/LinearAlgebraTest.scala
@@ -80,6 +80,9 @@ class LinearAlgebraTest extends FunSuite with Checkers with ShouldMatchers {
 
     val C = Matrix((1,2,3),(2,4,6),(0,-1,0)) // 1st and 2nd row linearly dep.
     det(C) should be (0.0 plusOrMinus 1e-15)
+
+    val D = Matrix((-1,1,-1),(1,2,3),(3,-10,1))
+    det(D) should be (-8.0 plusOrMinus 1e-8)
   }
 
   test("inv") {


### PR DESCRIPTION
This pull request fixes the det() method to correctly count the number of swapped rows in the LU() factorization.  The fix corrects the sign of the determinant for certain matrices.
