### PR TITLE
ProguardPlugin not found

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,4 @@
-
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-proguard-plugin" % (v+"-0.1.1"))
-
-resolvers += "Proguard plugin repo" at "http://siasia.github.com/maven2"
+// resolvers += "Proguard plugin repo" at "http://siasia.github.com/maven2"
 
 // addSbtPlugin("com.github.siasia" % "xsbt-proguard-plugin" % "0.1-SNAPSHOT")
 

--- a/project/plugins/build.sbt
+++ b/project/plugins/build.sbt
@@ -1,0 +1,2 @@
+libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-proguard-plugin" % (v+"-0.1.1"))
+

--- a/src/main/scala/scalala/tensor/dense/DenseVector.scala
+++ b/src/main/scala/scalala/tensor/dense/DenseVector.scala
@@ -418,7 +418,6 @@ extends DenseVector[V] with mutable.VectorRow[V] with mutable.VectorRowLike[V,De
       length = range.size);
   }
 
-
   override def newBuilder[K2,V2:Scalar](domain : IterableDomain[K2]) = {
     implicit val mf = implicitly[Scalar[V2]].manifest;
     domain match {
@@ -429,6 +428,9 @@ extends DenseVector[V] with mutable.VectorRow[V] with mutable.VectorRowLike[V,De
 
   override def t : DenseVectorCol[V] =
     new DenseVectorCol(data, offset, stride, length)(scalar);
+
+  // Override asRow to avoid unnecessary copies.
+  @inline override def asRow: DenseVectorRow[V] = this
 }
 
 /**
@@ -466,6 +468,9 @@ extends DenseVector[V] with mutable.VectorCol[V] with mutable.VectorColLike[V,De
 
   override def t : DenseVectorRow[V] =
     new DenseVectorRow(data, offset, stride, length)(scalar);
+
+  // Override asCol to avoid unnecessary copies.
+  @inline override def asCol: DenseVectorCol[V] = this
 }
 
 /**


### PR DESCRIPTION
Hi,

after pulling the latest commits from Scalala's master branch, sbt would refuse to work even after deleting all target directories and the ivy cache:

```
[info] Resolving org.scala-tools.sbt#precompiled-2_8_1;0.11.2 ...
[info] Resolving org.scala-tools.sbt#precompiled-2_8_0;0.11.2 ...
[info] Resolving org.scala-tools.sbt#precompiled-2_9_0;0.11.2 ...
[info] Done updating.
/Users/alex/src/git/Scalala/build.sbt:72: error: not found: value ProguardPlugin
seq(ProguardPlugin.proguardSettings :_*)
    ^
[error] Type error in expression
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? r
```

It turns out that the library dependency for the xsbt proguard plugin needs to be placed into project/plugins/build.sbt in accordance with what the [author says](https://github.com/siasia/xsbt-proguard-plugin/blob/master/README.md) on his page.
