### PR TITLE
CanLog and CanExp for vectors and matrices

### DIFF
--- a/src/main/scala/scalala/generic/math/CanExp.scala
+++ b/src/main/scala/scalala/generic/math/CanExp.scala
@@ -24,8 +24,9 @@ package math;
 
 import collection.CanMapValues;
 
-import scalala.operators.{UnaryOp,OpType};
+import scalala.operators.{UnaryOp}
 import scalala.scalar.Complex
+import scalala.tensor.{Matrix, Vector}
 
 /**
  * Operator type for exp(A).
@@ -77,5 +78,15 @@ object CanExp {
   implicit object OpArrayF extends OpMapValues[Array[Float],Float,Double,Array[Double]]()(OpF,CanMapValues.OpArrayFD);
   implicit object OpArrayD extends OpMapValues[Array[Double],Double,Double,Array[Double]]()(OpD,CanMapValues.OpArrayDD);
   implicit object OpArrayC extends OpMapValues[Array[Complex],Complex,Complex,Array[Complex]]()(OpC,CanMapValues.OpArrayCC);
+
+  implicit object OpVectorI extends OpMapValues[Vector[Int],Int,Double,Vector[Double]]()
+  implicit object OpVectorL extends OpMapValues[Vector[Long],Long,Double,Vector[Double]]()
+  implicit object OpVectorF extends OpMapValues[Vector[Float],Float,Double,Vector[Double]]()
+  implicit object OpVectorD extends OpMapValues[Vector[Double],Double,Double,Vector[Double]]()
+
+  implicit object OpMatrixI extends OpMapValues[Matrix[Int],Int,Double,Matrix[Double]]()
+  implicit object OpMatrixL extends OpMapValues[Matrix[Long],Long,Double,Matrix[Double]]()
+  implicit object OpMatrixF extends OpMapValues[Matrix[Float],Float,Double,Matrix[Double]]()
+  implicit object OpMatrixD extends OpMapValues[Matrix[Double],Double,Double,Matrix[Double]]()
 }
 

--- a/src/main/scala/scalala/generic/math/CanLog.scala
+++ b/src/main/scala/scalala/generic/math/CanLog.scala
@@ -23,8 +23,9 @@ package generic;
 package math;
 
 import collection.CanMapValues;
-
-import scalala.operators.{UnaryOp,OpType};
+import scalala.operators.UnaryOp
+import tensor.{Matrix, Vector}
+;
 
 /**
  * Operator type for log(A).
@@ -59,7 +60,7 @@ object CanLog {
   implicit object OpD extends CanLog[Double,Double] {
     def apply(v : Double) = scala.math.log(v);
   }
-
+  
   class OpMapValues[From,A,B,To](implicit op : CanLog[A,B], map : CanMapValues[From,A,B,To]) extends CanLog[From,To] {
     def apply(v : From) = map.map(v, op.apply(_));
   }
@@ -71,5 +72,15 @@ object CanLog {
   implicit object OpArrayL extends OpMapValues[Array[Long],Long,Double,Array[Double]]()(OpL,CanMapValues.OpArrayLD);
   implicit object OpArrayF extends OpMapValues[Array[Float],Float,Double,Array[Double]]()(OpF,CanMapValues.OpArrayFD);
   implicit object OpArrayD extends OpMapValues[Array[Double],Double,Double,Array[Double]]()(OpD,CanMapValues.OpArrayDD);
+
+  implicit object OpVectorI extends OpMapValues[Vector[Int],Int,Double,Vector[Double]]()
+  implicit object OpVectorL extends OpMapValues[Vector[Long],Long,Double,Vector[Double]]()
+  implicit object OpVectorF extends OpMapValues[Vector[Float],Float,Double,Vector[Double]]()
+  implicit object OpVectorD extends OpMapValues[Vector[Double],Double,Double,Vector[Double]]()
+
+  implicit object OpMatrixI extends OpMapValues[Matrix[Int],Int,Double,Matrix[Double]]()
+  implicit object OpMatrixL extends OpMapValues[Matrix[Long],Long,Double,Matrix[Double]]()
+  implicit object OpMatrixF extends OpMapValues[Matrix[Float],Float,Double,Matrix[Double]]()
+  implicit object OpMatrixD extends OpMapValues[Matrix[Double],Double,Double,Matrix[Double]]()
 }
 

--- a/src/main/scala/scalala/library/LinearAlgebra.scala
+++ b/src/main/scala/scalala/library/LinearAlgebra.scala
@@ -354,10 +354,11 @@ trait LinearAlgebra {
     //Perform the QR factorization with dgeqrf
     val maxd = math.max(m,n)
     val mind = math.max(m,n)
+    val tau = new Array[Double](mind)
     val outputMat = DenseMatrix.zeros[Double](m,maxd)
-    val tau = new Array[Double](math.min(m,n))
-    for(r <- 0 until m; c <- 0 until n) outputMat(r,c) = A(r,c)
-    lapack.dgeqrf(m, n, outputMat.data, m, workspace, tau, workspace.length, info);
+    for(r <- 0 until m; c <- 0 until n)
+      outputMat(r,c) = A(r,c)
+    lapack.dgeqrf(m, n, outputMat.data, m, tau, workspace, workspace.length, info);
 
     //Error check
     if (info.`val` > 0)
@@ -367,8 +368,7 @@ trait LinearAlgebra {
 
     //Get R
     val R = DenseMatrix.zeros[Double](m,n)
-    for(c <- 0 until maxd if(c < n);
-        r <- 0 until m if(r <= c))
+    for(c <- 0 until maxd if(c < n); r <- 0 until m if(r <= c))
       R(r,c) = outputMat(r,c)
 
     //unless the skipq flag is set
@@ -391,8 +391,8 @@ trait LinearAlgebra {
     else (null,R)
   }
 
-  
-  
+
+
 
   /**
    * Computes all eigenvalues (and optionally right eigenvectors) of the given

--- a/src/main/scala/scalala/tensor/dense/DenseVector.scala
+++ b/src/main/scala/scalala/tensor/dense/DenseVector.scala
@@ -418,7 +418,6 @@ extends DenseVector[V] with mutable.VectorRow[V] with mutable.VectorRowLike[V,De
       length = range.size);
   }
 
-
   override def newBuilder[K2,V2:Scalar](domain : IterableDomain[K2]) = {
     implicit val mf = implicitly[Scalar[V2]].manifest;
     domain match {
@@ -429,6 +428,9 @@ extends DenseVector[V] with mutable.VectorRow[V] with mutable.VectorRowLike[V,De
 
   override def t : DenseVectorCol[V] =
     new DenseVectorCol(data, offset, stride, length)(scalar);
+
+  // Override asRow to avoid unnecessary copies.
+  @inline override def asRow: DenseVectorRow[V] = this
 }
 
 /**
@@ -466,6 +468,9 @@ extends DenseVector[V] with mutable.VectorCol[V] with mutable.VectorColLike[V,De
 
   override def t : DenseVectorRow[V] =
     new DenseVectorRow(data, offset, stride, length)(scalar);
+
+  // Override asCol to avoid unnecessary copies.
+  @inline override def asCol: DenseVectorCol[V] = this
 }
 
 /**

--- a/src/test/scala/scalala/library/LibraryTest.scala
+++ b/src/test/scala/scalala/library/LibraryTest.scala
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith
 import scalala.scalar.Complex
 import scalala.tensor.mutable.{Matrix, Vector}
 import Library._
-import tensor.dense.{DenseVectorCol, DenseVector}
+import tensor.dense.{DenseVector, DenseMatrix}
 
 @RunWith(classOf[JUnitRunner])
 class LibraryTest extends FunSuite with Checkers with ShouldMatchers {
@@ -37,6 +37,8 @@ class LibraryTest extends FunSuite with Checkers with ShouldMatchers {
     assert(log(2.8) === 1.0296194171811581)
     assert(log(1) === 0)
     assert(log(Array(1,2,3,4)).toList === List(0.0, 0.6931471805599453, 1.0986122886681098, 1.3862943611198906))
+    assert(log(DenseVector(1,2,3,4)) === DenseVector(0.0, 0.6931471805599453, 1.0986122886681098, 1.3862943611198906))
+    assert(log(DenseMatrix((1,2,3,4))) === DenseMatrix((0.0, 0.6931471805599453, 1.0986122886681098, 1.3862943611198906)))
   }
 
   test("mean") {
@@ -58,7 +60,11 @@ class LibraryTest extends FunSuite with Checkers with ShouldMatchers {
   }
 
   test("exp") {
-    assert(exp(Array(1,2,3,4)).toList === List(1,2,3,4).map(_.toDouble).map(math.exp))
+    exp(1.0296194171811581) should be (2.8)
+    exp(0) should be (1)
+    exp(Array(0.0, 0.6931471805599453, 1.0986122886681098, 1.3862943611198906)) should equal (Array(1,2,3,4))
+    exp(DenseVector(0.0, 0.6931471805599453, 1.0986122886681098, 1.3862943611198906)).toList should equal (List(1,2,3,4))
+    exp(DenseMatrix((0.0, 0.6931471805599453, 1.0986122886681098, 1.3862943611198906))) should equal (DenseMatrix((1,2,3,4)))
   }
 
   test("Complex:exp") {

--- a/src/test/scala/scalala/library/LinearAlgebraTest.scala
+++ b/src/test/scala/scalala/library/LinearAlgebraTest.scala
@@ -137,4 +137,23 @@ class LinearAlgebraTest extends FunSuite with Checkers with ShouldMatchers {
     assert(rank(r3) === 3)
   }
 
+  test("qr") {
+    val A = Matrix((1.0, 1.0, 1.0), (4.0, 2.0, 1.0), (16.0, 4.0, 1.0))
+    val (_Q, _R) = qr(A)
+
+    val expectedQ = Matrix((-0.06052275326,-0.6022239035,-0.7960297521),
+                           (-0.2420910130,-0.7648243574,0.5970223140),
+                           (-0.9683640522,0.2288450833,-0.09950371901))
+    _Q.numRows should  be (expectedQ.numRows)
+    _Q.numCols should  be (expectedQ.numCols)
+    _Q foreachPair { case ((i,j), v) => v should be (expectedQ(i,j) plusOrMinus 1e-8) }
+
+    val expectedR = Matrix((-16.52271164,-4.418160988,-1.270977818),
+      (0.,-1.216492285,-1.138203178),
+      (0.,0.,-0.2985111571))
+    _R.numRows should  be (expectedR.numRows)
+    _R.numCols should  be (expectedR.numCols)
+    _R foreachPair { case ((i,j), v) => v should be (expectedR(i,j) plusOrMinus 1e-8) }
+  }
+
 }


### PR DESCRIPTION
Hi,

I was in need of log and exp for vectors and matrices, and thought I'd share. Sorry for the many pull requests lately.

EDIT: Added a bugfix for LinearAlgebra.qr() where arguments to LAPACK were messed up accidentally.

Best regards,
Alexander
