### PR TITLE
Updated build to use Scala 2.9.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,9 @@ version := "1.0.0.RC3-SNAPSHOT"
 
 organization := "org.scalala"
 
-scalaVersion := "2.9.1"
+scalaVersion := "2.9.2"
 
-crossScalaVersions := Seq("2.8.2", "2.9.1")
+crossScalaVersions := Seq("2.8.2", "2.9.2")
 
 resolvers ++= Seq(
   "ScalaNLP Maven2" at "http://repo.scalanlp.org/repo",
@@ -31,7 +31,7 @@ libraryDependencies <<= (scalaVersion, libraryDependencies) { (sv, deps) =>
 
 libraryDependencies <<= (scalaVersion, libraryDependencies) { (sv, deps) =>
   sv match {
-    case "2.9.1" =>
+    case "2.9.2" =>
       deps :+ ("jline" % "jline" % "0.9.94") // ("org.scala-lang" % "jline" % "2.9.1")
     case x if x.startsWith("2.8") =>
       deps :+ ("jline" % "jline" % "0.9.94")
@@ -41,9 +41,9 @@ libraryDependencies <<= (scalaVersion, libraryDependencies) { (sv, deps) =>
 
 libraryDependencies <<= (scalaVersion, libraryDependencies) { (sv, deps) =>
   sv match {
-    case "2.9.1" =>
+    case "2.9.2" =>
       (deps :+ ("org.scalatest" % "scalatest" % "1.4.RC2" % "test")
-            :+ ("org.scala-tools.testing" %% "scalacheck" % "1.9" % "test"))
+            :+ ("org.scala-tools.testing" % "scalacheck_2.9.1" % "1.9" % "test"))
     case x if x.startsWith("2.8") =>
       (deps :+ ("org.scalatest" % "scalatest" % "1.3" % "test")
             :+ ("org.scala-tools.testing" % "scalacheck_2.8.1" % "1.8" % "test"))


### PR DESCRIPTION
Hi,
I've updated the build to use Scala 2.9.2 instead of 2.9.1.

At the moment it is only cross-built to 2.9.2 and 2.8.2 (as previously), as I did not think 2.9.1 was required anymore given that 2.9.x should be binary compatible. However if you want to keep a 2.9.1 cross-build, let me know and I'll add it to another pull request assuming you reject this.
